### PR TITLE
Refactor projects page into research themes

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,6 +3,9 @@ main:
   - title: "Publications"
     url: /publications/
 
+  - title: "Research Themes"
+    url: /research/
+
   - title: "CV"
     url: /cv/
     

--- a/_pages/research-themes.md
+++ b/_pages/research-themes.md
@@ -1,0 +1,36 @@
+---
+title: "Research Themes"
+permalink: /research/
+author_profile: true
+---
+
+This page provides an overview of my main research themes with links to relevant publications.
+
+## Semantic Mapping & Planning
+- [Object guided autonomous exploration for mobile robots in indoor environments](/publication/2014-01-01-Object-guided-autonomous-exploration-for-mobile-robots-in-indoor-environments)
+- [Active planning based extrinsic calibration of exteroceptive sensors in unknown environments](/publication/2016-01-01-Active-planning-based-extrinsic-calibration-of-exteroceptive-sensors-in-unknown-environments)
+- [Utilizing semantic visual landmarks for precise vehicle navigation](/publication/2017-01-01-Utilizing-semantic-visual-landmarks-for-precise-vehicle-navigation)
+- [Challenges and Opportunities for Large-Scale Exploration with Air-Ground Teams using Semantics](/publication/2024-01-01-Challenges-and-Opportunities-for-Large-Scale-Exploration-with-Air-Ground-Teams-using-Semantics)
+- [SPINE: Online Semantic Planning for Missions with Incomplete Natural Language Specifications in Unstructured Environments](/publication/2024-01-01-SPINE-Online-Semantic-Planning-for-Missions-with-Incomplete-Natural-Language-Specifications-in-Unstructured-Environments)
+
+## Trajectory Optimization & Planning
+- [Perception-aware trajectory generation for aggressive quadrotor flight using differential flatness](/publication/2019-01-01-Perception-aware-trajectory-generation-for-aggressive-quadrotor-flight-using-differential-flatness)
+- [Asymptotic optimality of a time optimal path parametrization algorithm](/publication/2019-01-01-Asymptotic-optimality-of-a-time-optimal-path-parametrization-algorithm)
+- [Joint Feature Selection and Time Optimal Path Parametrization for High Speed Vision-Aided Navigation](/publication/2020-01-01-Joint-Feature-Selection-and-Time-Optimal-Path-Parametrization-for-High-Speed-Vision-Aided-Navigation)
+- [Perception-aware time optimal path parameterization for quadrotors](/publication/2020-01-01-Perception-aware-time-optimal-path-parameterization-for-quadrotors)
+- [RT-GuIDE: Real-Time Gaussian splatting for Information-Driven Exploration](/publication/2024-01-01-RT-GuIDE-Real-Time-Gaussian-splatting-for-Information-Driven-Exploration)
+
+## Datasets & Simulation
+- [Flightgoggles: Photorealistic sensor simulation for perception-driven robotics using photogrammetry and virtual reality](/publication/2019-01-01-Flightgoggles-Photorealistic-sensor-simulation-for-perception-driven-robotics-using-photogrammetry-and-virtual-reality)
+- [The blackbird dataset: A large-scale dataset for UAV perception in aggressive flight](/publication/2018-01-01-The-blackbird-dataset-A-large-scale-dataset-for-uav-perception-in-aggressive-flight)
+- [The blackbird UAV dataset](/publication/2020-01-01-The-blackbird-uav-dataset)
+
+## Perception Algorithms & Pose Estimation
+- [6D object pose estimation with pairwise compatible geometric features](/publication/2021-01-01-6D-object-pose-estimation-with-pairwise-compatible-geometric-features)
+- [A planted clique perspective on hypothesis pruning](/publication/2022-01-01-A-planted-clique-perspective-on-hypothesis-pruning)
+
+## Applications
+- [Augmented reality driving using semantic geo-registration](/publication/2018-01-01-Augmented-reality-driving-using-semantic-geo-registration)
+- [Learning autonomous driving from aerial imagery](/publication/2024-01-01-Learning-autonomous-driving-from-aerial-imagery)
+- [AgriNeRF: Neural Radiance Fields for Agriculture in Challenging Lighting Conditions](/publication/2024-01-01-AgriNeRF-Neural-Radiance-Fields-for-Agriculture-in-Challenging-Lighting-Conditions)
+- [User oriented assessment of vibration suppression by command shaping in a supernumerary wearable robotic arm](/publication/2016-01-01-User-oriented-assessment-of-vibration-suppression-by-command-shaping-in-a-supernumerary-wearable-robotic-arm)


### PR DESCRIPTION
## Summary
- rename projects page to research themes
- update navigation to reference the new page
- clarify headings for semantic mapping vs pure perception

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446205ed08833181fcb1b20552c35a